### PR TITLE
feat(settings): add language selector

### DIFF
--- a/electron/src/lib/app-settings.ts
+++ b/electron/src/lib/app-settings.ts
@@ -14,7 +14,7 @@ import { getDataDir } from "./data-dir";
 import type { AppSettings, NotificationSettings } from "@shared/types/settings";
 
 // Re-export shared types so existing `import from "./app-settings"` consumers still work
-export type { AppSettings, MacBackgroundEffect, PreferredEditor, VoiceDictationMode, NotificationTrigger, NotificationEventSettings, NotificationSettings, CodexBinarySource, ClaudeBinarySource } from "@shared/types/settings";
+export type { AppSettings, AppLanguage, MacBackgroundEffect, PreferredEditor, VoiceDictationMode, NotificationTrigger, NotificationEventSettings, NotificationSettings, CodexBinarySource, ClaudeBinarySource } from "@shared/types/settings";
 
 const NOTIFICATION_DEFAULTS: NotificationSettings = {
   exitPlanMode: { osNotification: "unfocused", sound: "always" },
@@ -28,6 +28,7 @@ const DEFAULTS: AppSettings = {
   defaultChatLimit: 10,
   preferredEditor: "auto",
   voiceDictation: "native",
+  language: "en",
   notifications: NOTIFICATION_DEFAULTS,
   codexClientName: "Harnss",
   codexBinarySource: "auto",

--- a/shared/types/settings.ts
+++ b/shared/types/settings.ts
@@ -9,6 +9,7 @@
 export type PreferredEditor = "auto" | "cursor" | "code" | "zed";
 export type VoiceDictationMode = "native" | "whisper";
 export type ThemeOption = "light" | "dark" | "system";
+export type AppLanguage = "en" | "zh-CN";
 export type MacBackgroundEffect = "liquid-glass" | "vibrancy" | "off";
 export type CodexBinarySource = "auto" | "managed" | "custom";
 export type ClaudeBinarySource = "auto" | "managed" | "custom";
@@ -41,6 +42,8 @@ export interface AppSettings {
   preferredEditor: PreferredEditor;
   /** Voice dictation mode: "native" uses OS dictation, "whisper" uses local AI model (default: "native") */
   voiceDictation: VoiceDictationMode;
+  /** UI language (default: "en") */
+  language: AppLanguage;
   /** Per-event notification and sound configuration */
   notifications: NotificationSettings;
   /** Custom client name sent to Codex servers during handshake (default: "Harnss") */

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -27,6 +27,7 @@ import { AboutSettings } from "@/components/settings/AboutSettings";
 import { AnalyticsSettings } from "@/components/settings/AnalyticsSettings";
 import { useSettingsStore } from "@/stores/settings-store";
 import { isMac } from "@/lib/utils";
+import { DEFAULT_LANGUAGE, t, type TranslationKey } from "@/lib/i18n";
 import type { AppSettings } from "@/types";
 import { useAgentContext } from "./AgentContext";
 
@@ -36,24 +37,24 @@ export type SettingsSection = "general" | "appearance" | "notifications" | "anal
 
 interface NavItem {
   id: SettingsSection;
-  label: string;
+  label: TranslationKey;
   icon: LucideIcon;
   /** Renders a subtle "soon" indicator next to the label */
   comingSoon?: boolean;
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { id: "general", label: "General", icon: SlidersHorizontal },
-  { id: "appearance", label: "Appearance", icon: Palette },
-  { id: "notifications", label: "Notifications", icon: Bell },
-  { id: "analytics", label: "Analytics", icon: BarChart3 },
-  { id: "agents", label: "ACP Agents", icon: Bot },
-  { id: "mcp", label: "MCP Servers", icon: Plug },
-  { id: "engines", label: "Engines", icon: Cpu },
-  { id: "skills", label: "Skills", icon: Sparkles, comingSoon: true },
-  { id: "custom-agents", label: "Agents", icon: Users, comingSoon: true },
-  { id: "advanced", label: "Advanced", icon: Wrench },
-  { id: "about", label: "About", icon: Info },
+  { id: "general", label: "settings.nav.general", icon: SlidersHorizontal },
+  { id: "appearance", label: "settings.nav.appearance", icon: Palette },
+  { id: "notifications", label: "settings.nav.notifications", icon: Bell },
+  { id: "analytics", label: "settings.nav.analytics", icon: BarChart3 },
+  { id: "agents", label: "settings.nav.acpAgents", icon: Bot },
+  { id: "mcp", label: "settings.nav.mcpServers", icon: Plug },
+  { id: "engines", label: "settings.nav.engines", icon: Cpu },
+  { id: "skills", label: "settings.nav.skills", icon: Sparkles, comingSoon: true },
+  { id: "custom-agents", label: "settings.nav.customAgents", icon: Users, comingSoon: true },
+  { id: "advanced", label: "settings.nav.advanced", icon: Wrench },
+  { id: "about", label: "settings.nav.about", icon: Info },
 ];
 
 // ── Props ──
@@ -88,6 +89,7 @@ export const SettingsView = memo(function SettingsView({
 
   // ── Main-process app settings (loaded once, updated optimistically) ──
   const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
+  const language = appSettings?.language ?? DEFAULT_LANGUAGE;
 
   useEffect(() => {
     window.claude.settings.get().then((s: AppSettings | null) => {
@@ -117,6 +119,7 @@ export const SettingsView = memo(function SettingsView({
           <GeneralSettings
             appSettings={appSettings}
             onUpdateAppSettings={updateAppSettings}
+            language={language}
           />
         );
       case "appearance":
@@ -169,7 +172,7 @@ export const SettingsView = memo(function SettingsView({
         return (
           <PlaceholderSection
             title="Skills"
-            description="Create, install, and manage agent skills that extend what your AI coding agents can do."
+            description={t(language, "settings.placeholder.skills.description")}
             icon={Sparkles}
             comingSoon
           />
@@ -178,7 +181,7 @@ export const SettingsView = memo(function SettingsView({
         return (
           <PlaceholderSection
             title="Agents"
-            description="Build and configure custom agents with specialized tools, prompts, and workflows."
+            description={t(language, "settings.placeholder.customAgents.description")}
             icon={Users}
             comingSoon
           />
@@ -188,7 +191,7 @@ export const SettingsView = memo(function SettingsView({
       default:
         return null;
     }
-  }, [activeSection, appSettings, updateAppSettings, agents, saveAgent, deleteAgent, glassSupported, macLiquidGlassSupported, onReplayWelcome]);
+  }, [activeSection, appSettings, updateAppSettings, language, agents, saveAgent, deleteAgent, glassSupported, macLiquidGlassSupported, onReplayWelcome]);
 
   return (
     <div className={`island flex flex-1 flex-col overflow-hidden bg-background ${islandLayout ? "rounded-[var(--island-radius)]" : "rounded-none"}`}>
@@ -209,7 +212,7 @@ export const SettingsView = memo(function SettingsView({
             <PanelLeft className="h-4 w-4" />
           </Button>
         )}
-        <span className={`leading-none text-sm font-semibold text-foreground ${macIslandTitlebarOffsetClass}`}>Settings</span>
+        <span className={`leading-none text-sm font-semibold text-foreground ${macIslandTitlebarOffsetClass}`}>{t(language, "settings.title")}</span>
       </div>
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
@@ -231,10 +234,10 @@ export const SettingsView = memo(function SettingsView({
                   }`}
                 >
                   <Icon className="h-4 w-4 shrink-0" />
-                  <span className="flex-1">{item.label}</span>
+                  <span className="flex-1">{t(language, item.label)}</span>
                   {item.comingSoon && (
                     <span className="rounded bg-foreground/[0.06] px-1.5 py-px text-[10px] font-medium text-muted-foreground/70">
-                      Soon
+                      {t(language, "settings.nav.soon")}
                     </span>
                   )}
                 </button>

--- a/src/components/settings/GeneralSettings.tsx
+++ b/src/components/settings/GeneralSettings.tsx
@@ -1,13 +1,15 @@
 import { memo, useState, useCallback, useEffect } from "react";
-import { Download, MessageSquare, Code, Mic } from "lucide-react";
+import { Download, MessageSquare, Code, Mic, Languages } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { SettingRow, SettingsSelect, SettingsHeader, SettingsSection } from "@/components/settings/shared";
-import type { AppSettings, PreferredEditor, VoiceDictationMode } from "@/types";
+import { DEFAULT_LANGUAGE, t } from "@/lib/i18n";
+import type { AppLanguage, AppSettings, PreferredEditor, VoiceDictationMode } from "@/types";
 
 interface GeneralSettingsProps {
   appSettings: AppSettings | null;
   onUpdateAppSettings: (patch: Partial<AppSettings>) => Promise<void>;
+  language?: AppLanguage;
 }
 
 // ── Component ──
@@ -15,12 +17,14 @@ interface GeneralSettingsProps {
 export const GeneralSettings = memo(function GeneralSettings({
   appSettings,
   onUpdateAppSettings,
+  language = DEFAULT_LANGUAGE,
 }: GeneralSettingsProps) {
   // Local optimistic state — synced from props once loaded
   const [allowPrerelease, setAllowPrerelease] = useState(false);
   const [chatLimit, setChatLimit] = useState(10);
   const [preferredEditor, setPreferredEditor] = useState<PreferredEditor>("auto");
   const [voiceDictation, setVoiceDictation] = useState<VoiceDictationMode>("native");
+  const [selectedLanguage, setSelectedLanguage] = useState<AppLanguage>(language);
 
   useEffect(() => {
     if (appSettings) {
@@ -28,6 +32,7 @@ export const GeneralSettings = memo(function GeneralSettings({
       setChatLimit(appSettings.defaultChatLimit || 10);
       setPreferredEditor(appSettings.preferredEditor || "auto");
       setVoiceDictation(appSettings.voiceDictation || "native");
+      setSelectedLanguage(appSettings.language || DEFAULT_LANGUAGE);
     }
   }, [appSettings]);
 
@@ -64,17 +69,41 @@ export const GeneralSettings = memo(function GeneralSettings({
     [onUpdateAppSettings],
   );
 
+  const handleLanguageChange = useCallback(
+    async (value: AppLanguage) => {
+      setSelectedLanguage(value);
+      await onUpdateAppSettings({ language: value });
+    },
+    [onUpdateAppSettings],
+  );
+
   return (
     <div className="flex h-full flex-col">
-      <SettingsHeader title="General" description="Application-wide preferences" />
+      <SettingsHeader title={t(language, "settings.general.title")} description={t(language, "settings.general.description")} />
 
       <ScrollArea className="min-h-0 flex-1">
         <div className="px-6 py-2">
-          {/* ── Updates section ── */}
-          <SettingsSection icon={Download} label="Updates" first>
+          <SettingsSection icon={Languages} label={t(language, "settings.general.language.section")} first>
             <SettingRow
-              label="Include pre-release updates"
-              description="Receive beta versions with the latest features. Disable to only get stable releases."
+              label={t(language, "settings.general.language.label")}
+              description={t(language, "settings.general.language.description")}
+            >
+              <SettingsSelect
+                value={selectedLanguage}
+                onValueChange={handleLanguageChange}
+                options={[
+                  { value: "en", label: t(language, "settings.general.language.english") },
+                  { value: "zh-CN", label: t(language, "settings.general.language.chinese") },
+                ]}
+              />
+            </SettingRow>
+          </SettingsSection>
+
+          {/* ── Updates section ── */}
+          <SettingsSection icon={Download} label={t(language, "settings.general.updates.section")}>
+            <SettingRow
+              label={t(language, "settings.general.updates.prerelease.label")}
+              description={t(language, "settings.general.updates.prerelease.description")}
             >
               <Switch
                 checked={allowPrerelease}
@@ -84,10 +113,10 @@ export const GeneralSettings = memo(function GeneralSettings({
           </SettingsSection>
 
           {/* ── Sidebar section ── */}
-          <SettingsSection icon={MessageSquare} label="Sidebar">
+          <SettingsSection icon={MessageSquare} label={t(language, "settings.general.sidebar.section")}>
             <SettingRow
-              label="Recent chats per project"
-              description="Number of chats shown by default in each project. Click 'Show more' in the sidebar to load additional chats."
+              label={t(language, "settings.general.sidebar.chatLimit.label")}
+              description={t(language, "settings.general.sidebar.chatLimit.description")}
             >
               <SettingsSelect
                 value={String(chatLimit)}
@@ -98,16 +127,16 @@ export const GeneralSettings = memo(function GeneralSettings({
           </SettingsSection>
 
           {/* ── Editor section ── */}
-          <SettingsSection icon={Code} label="Editor">
+          <SettingsSection icon={Code} label={t(language, "settings.general.editor.section")}>
             <SettingRow
-              label="Default editor"
-              description="Choose which editor opens when you click 'Open in Editor'. Auto tries Cursor, VS Code, then Zed."
+              label={t(language, "settings.general.editor.default.label")}
+              description={t(language, "settings.general.editor.default.description")}
             >
               <SettingsSelect
                 value={preferredEditor}
                 onValueChange={handleEditorChange}
                 options={[
-                  { value: "auto", label: "Auto" },
+                  { value: "auto", label: t(language, "settings.general.editor.auto") },
                   { value: "cursor", label: "Cursor" },
                   { value: "code", label: "VS Code" },
                   { value: "zed", label: "Zed" },
@@ -117,17 +146,17 @@ export const GeneralSettings = memo(function GeneralSettings({
           </SettingsSection>
 
           {/* ── Voice Dictation section ── */}
-          <SettingsSection icon={Mic} label="Voice Dictation">
+          <SettingsSection icon={Mic} label={t(language, "settings.general.voice.section")}>
             <SettingRow
-              label="Dictation mode"
-              description="Native uses your OS dictation (macOS only). Whisper runs a local AI model for speech-to-text on all platforms (~40 MB download on first use)."
+              label={t(language, "settings.general.voice.mode.label")}
+              description={t(language, "settings.general.voice.mode.description")}
             >
               <SettingsSelect
                 value={voiceDictation}
                 onValueChange={handleVoiceDictationChange}
                 options={[
-                  { value: "native", label: "Native (OS)" },
-                  { value: "whisper", label: "Whisper (Local AI)" },
+                  { value: "native", label: t(language, "settings.general.voice.native") },
+                  { value: "whisper", label: t(language, "settings.general.voice.whisper") },
                 ]}
               />
             </SettingRow>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,135 @@
+import type { AppLanguage } from "@/types";
+
+export type TranslationKey =
+  | "settings.title"
+  | "settings.nav.general"
+  | "settings.nav.appearance"
+  | "settings.nav.notifications"
+  | "settings.nav.analytics"
+  | "settings.nav.acpAgents"
+  | "settings.nav.mcpServers"
+  | "settings.nav.engines"
+  | "settings.nav.skills"
+  | "settings.nav.customAgents"
+  | "settings.nav.advanced"
+  | "settings.nav.about"
+  | "settings.nav.soon"
+  | "settings.general.title"
+  | "settings.general.description"
+  | "settings.general.language.section"
+  | "settings.general.language.label"
+  | "settings.general.language.description"
+  | "settings.general.language.english"
+  | "settings.general.language.chinese"
+  | "settings.general.updates.section"
+  | "settings.general.updates.prerelease.label"
+  | "settings.general.updates.prerelease.description"
+  | "settings.general.sidebar.section"
+  | "settings.general.sidebar.chatLimit.label"
+  | "settings.general.sidebar.chatLimit.description"
+  | "settings.general.editor.section"
+  | "settings.general.editor.default.label"
+  | "settings.general.editor.default.description"
+  | "settings.general.editor.auto"
+  | "settings.general.voice.section"
+  | "settings.general.voice.mode.label"
+  | "settings.general.voice.mode.description"
+  | "settings.general.voice.native"
+  | "settings.general.voice.whisper"
+  | "settings.placeholder.skills.description"
+  | "settings.placeholder.customAgents.description";
+
+const EN: Record<TranslationKey, string> = {
+  "settings.title": "Settings",
+  "settings.nav.general": "General",
+  "settings.nav.appearance": "Appearance",
+  "settings.nav.notifications": "Notifications",
+  "settings.nav.analytics": "Analytics",
+  "settings.nav.acpAgents": "ACP Agents",
+  "settings.nav.mcpServers": "MCP Servers",
+  "settings.nav.engines": "Engines",
+  "settings.nav.skills": "Skills",
+  "settings.nav.customAgents": "Agents",
+  "settings.nav.advanced": "Advanced",
+  "settings.nav.about": "About",
+  "settings.nav.soon": "Soon",
+  "settings.general.title": "General",
+  "settings.general.description": "Application-wide preferences",
+  "settings.general.language.section": "Language",
+  "settings.general.language.label": "Language",
+  "settings.general.language.description": "Choose the display language for Harnss.",
+  "settings.general.language.english": "English",
+  "settings.general.language.chinese": "中文",
+  "settings.general.updates.section": "Updates",
+  "settings.general.updates.prerelease.label": "Include pre-release updates",
+  "settings.general.updates.prerelease.description": "Receive beta versions with the latest features. Disable to only get stable releases.",
+  "settings.general.sidebar.section": "Sidebar",
+  "settings.general.sidebar.chatLimit.label": "Recent chats per project",
+  "settings.general.sidebar.chatLimit.description": "Number of chats shown by default in each project. Click 'Show more' in the sidebar to load additional chats.",
+  "settings.general.editor.section": "Editor",
+  "settings.general.editor.default.label": "Default editor",
+  "settings.general.editor.default.description": "Choose which editor opens when you click 'Open in Editor'. Auto tries Cursor, VS Code, then Zed.",
+  "settings.general.editor.auto": "Auto",
+  "settings.general.voice.section": "Voice Dictation",
+  "settings.general.voice.mode.label": "Dictation mode",
+  "settings.general.voice.mode.description": "Native uses your OS dictation (macOS only). Whisper runs a local AI model for speech-to-text on all platforms (~40 MB download on first use).",
+  "settings.general.voice.native": "Native (OS)",
+  "settings.general.voice.whisper": "Whisper (Local AI)",
+  "settings.placeholder.skills.description": "Create, install, and manage agent skills that extend what your AI coding agents can do.",
+  "settings.placeholder.customAgents.description": "Build and configure custom agents with specialized tools, prompts, and workflows.",
+};
+
+const ZH_CN: Record<TranslationKey, string> = {
+  "settings.title": "设置",
+  "settings.nav.general": "通用",
+  "settings.nav.appearance": "外观",
+  "settings.nav.notifications": "通知",
+  "settings.nav.analytics": "分析",
+  "settings.nav.acpAgents": "ACP Agent",
+  "settings.nav.mcpServers": "MCP 服务器",
+  "settings.nav.engines": "引擎",
+  "settings.nav.skills": "技能",
+  "settings.nav.customAgents": "Agent",
+  "settings.nav.advanced": "高级",
+  "settings.nav.about": "关于",
+  "settings.nav.soon": "即将推出",
+  "settings.general.title": "通用",
+  "settings.general.description": "应用级偏好设置",
+  "settings.general.language.section": "语言",
+  "settings.general.language.label": "语言",
+  "settings.general.language.description": "选择 Harnss 的显示语言。",
+  "settings.general.language.english": "English",
+  "settings.general.language.chinese": "中文",
+  "settings.general.updates.section": "更新",
+  "settings.general.updates.prerelease.label": "包含预发布版本更新",
+  "settings.general.updates.prerelease.description": "接收包含最新功能的测试版本。关闭后只接收稳定版本。",
+  "settings.general.sidebar.section": "侧边栏",
+  "settings.general.sidebar.chatLimit.label": "每个项目的最近聊天数",
+  "settings.general.sidebar.chatLimit.description": "每个项目默认显示的聊天数量。可在侧边栏点击“显示更多”加载额外聊天。",
+  "settings.general.editor.section": "编辑器",
+  "settings.general.editor.default.label": "默认编辑器",
+  "settings.general.editor.default.description": "选择点击“在编辑器中打开”时使用的编辑器。自动会依次尝试 Cursor、VS Code、Zed。",
+  "settings.general.editor.auto": "自动",
+  "settings.general.voice.section": "语音听写",
+  "settings.general.voice.mode.label": "听写模式",
+  "settings.general.voice.mode.description": "原生模式使用系统听写（仅 macOS）。Whisper 会在本地运行 AI 语音转文字模型（首次使用约需下载 40 MB）。",
+  "settings.general.voice.native": "原生（系统）",
+  "settings.general.voice.whisper": "Whisper（本地 AI）",
+  "settings.placeholder.skills.description": "创建、安装和管理用于扩展 AI 编程 Agent 能力的技能。",
+  "settings.placeholder.customAgents.description": "构建和配置带有专用工具、提示词和工作流的自定义 Agent。",
+};
+
+const TRANSLATIONS: Record<AppLanguage, Record<TranslationKey, string>> = {
+  en: EN,
+  "zh-CN": ZH_CN,
+};
+
+export const DEFAULT_LANGUAGE: AppLanguage = "en";
+
+export function isAppLanguage(value: string): value is AppLanguage {
+  return value === "en" || value === "zh-CN";
+}
+
+export function t(language: AppLanguage | undefined, key: TranslationKey): string {
+  return TRANSLATIONS[language ?? DEFAULT_LANGUAGE]?.[key] ?? EN[key];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,6 +98,7 @@ export type {
   PreferredEditor,
   VoiceDictationMode,
   ThemeOption,
+  AppLanguage,
   MacBackgroundEffect,
   CodexBinarySource,
   ClaudeBinarySource,


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 2-4 bullet points. -->

-
-

## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 🎨 UI / design improvement
- [ ] ⚡ Performance improvement
- [ ] ♻️ Refactor (no functional changes)
- [ ] 🧪 Tests / CI
- [ ] 📝 Documentation

## Related Issues

<!-- Link any related issues. Use "Closes #123" to auto-close on merge. -->

Closes #

## How to Test

<!-- Step-by-step instructions for reviewing / testing this change. -->

1.
2.
3.

## Screenshots / Screen Recording

<!-- If this changes any UI, please attach before/after screenshots or a short recording. -->

## Checklist

- [ ] I've tested this on macOS (required for Electron/native features)
- [ ] TypeScript compiles with no errors (`pnpm build`)
- [ ] No `any` types introduced
- [ ] Logical margins used (`ms-*`/`me-*` instead of `ml-*`/`mr-*`)
- [ ] User-generated content containers have `wrap-break-word`
- [ ] New shared types go in `shared/types/`, not `src/types/`
- [ ] Large components/hooks are decomposed into sub-components/sub-hooks if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced multi-language support with a new Language setting in General Settings
  * Users can now switch between English and Simplified Chinese for the entire interface
  * All interface labels, navigation items, section headers, and descriptive text display in the selected language
  * Language preference is automatically saved and persists across application sessions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSource03/harnss/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->